### PR TITLE
Replace async_std shim with tokio's spawn_blocking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,9 +19,8 @@ log = "0.4"
 
 futures = "0.3"
 tokio-rustls = "0.12"
-tokio = { version = "0.2", features = ["net"] }
+tokio = { version = "0.2", features = ["blocking", "net"] }
 hyper = "0.13"
-async-std = "1"
 
 [dev-dependencies]
 openssl = "0.10"


### PR DESCRIPTION
I figured that since hyper is tied to the Tokio stack anyway, leaving out a single shim from `async-std` that just wraps std's DNS resolver only inflates the dependency graph and introduces the additional overhead of having `async-std`'s threads on top of Tokio's. Therefore I replaced it with calling `std::net::ToSocketAddrs` directly using `tokio::task::spawn_blocking`. The long term solution, however, would be to look into fully asynchronous DNS resolver like `trust-dns`.