### PR TITLE
update deps to fix sec-0052 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.13.0"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "bitflags"
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "hyper-alpn"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "hyper",
  "log",
@@ -375,23 +375,33 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aab8ee6c7097ed6057f43c187a62418d0c05a4bd5f18b3571db50ee0f9ce033"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log",
  "ring",
+ "rustls-webpki",
  "sct",
- "webpki",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0864aeff53f8c05aa08d86e5ef839d3dfcf07aeba2db32f12db0ef716e87bd55"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
  "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c7d5dece342910d9ba34d259310cae3e0154b873b35408b787b59bce53d34fe"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -472,13 +482,12 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.23.4"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
  "rustls",
  "tokio",
- "webpki",
 ]
 
 [[package]]
@@ -626,23 +635,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "webpki-roots"
-version = "0.22.4"
+version = "0.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1c760f0d366a6c24a02ed7816e23e691f5d92291f94d15e836006fd11b04daf"
-dependencies = [
- "webpki",
-]
+checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,11 @@ edition = "2021"
 [dependencies]
 log = "0.4"
 
-rustls = "0.20"
-rustls-pemfile = "1.0.1"
-webpki-roots = "0.22"
+rustls = "0.21"
+rustls-pemfile = "1.0.3"
+webpki-roots = "0.25"
 
-tokio-rustls = "0.23"
+tokio-rustls = "0.24"
 tokio = { version = "1", features = ["net", "rt"] }
 
 hyper = { version = "0.14", features = ["client", "http2", "h2"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ impl AlpnConnector {
         let config = self
             .config_builder
             .clone()
-            .with_single_cert(cert_chain, rustls::PrivateKey(key_der));
+            .with_client_auth_cert(cert_chain, rustls::PrivateKey(key_der));
         match config {
             Ok(mut c) => {
                 c.alpn_protocols.push("h2".as_bytes().to_vec());
@@ -196,8 +196,8 @@ impl AlpnConnector {
     fn with_client_config(config: ConfigBuilder<ClientConfig, WantsCipherSuites>) -> Self {
         let mut root_cert_store = rustls::RootCertStore::empty();
 
-        root_cert_store.add_server_trust_anchors(
-            webpki_roots::TLS_SERVER_ROOTS.0.iter().map(|ta| {
+        root_cert_store.add_trust_anchors(
+            webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
                 OwnedTrustAnchor::from_subject_spki_name_constraints(ta.subject, ta.spki, ta.name_constraints)
             }),
         );


### PR DESCRIPTION
https://rustsec.org/advisories/RUSTSEC-2023-0052

previously relied upon outdated version of tokio-rustls which relied upon old non-forked version of webpki which had a sec issue

bumping all dependencies to latest fixes the issue. also corrected for usage of deprecated apis

## How Has This Been Tested?

`cargo test`

## Due Dilligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update